### PR TITLE
Added basic functionality for selecting trading pair + Default size now fills terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,16 @@ bitcoin-chart-cli --help
 
   Options:
 
-    -V, --version        output the version number
-    -d, --days <n>       number of days the chart will go back
-    --hours <n>          number of hours the chart will go back
-    --mins <n>           number of minutes the chart will go back
-    -w, --width <n>      max terminal chart width
-    -h, --height <n>     max terminal chart height
-    -c, --coin <string>  specify the coin e.g. ETH
-    --disable-legend     disable legend text
-    -h, --help           output usage information
+    -V, --version         output the version number
+    -d, --days <n>        number of days the chart will go back
+    --hours <n>           number of hours the chart will go back
+    --mins <n>            number of minutes the chart will go back
+    -w, --width <n>       max terminal chart width
+    -h, --height <n>      max terminal chart height
+    -c, --coin <string>   specify the coin e.g. ETH
+    -m, --market <string> specify the market e.g. USD, EUR, BTC
+    --disable-legend      disable legend text
+    -h, --help            output usage information
 ```
 # Examples
 

--- a/test.sh
+++ b/test.sh
@@ -15,3 +15,5 @@ node index.js --coin DASH -d 800
 node index.js -w 200 -h 80
 node index.js -w 80 -h 5
 node index.js --coin GNT --mins 60 -w 80 -h 5
+node index.js --coin ETH --market BTC -d 30
+node index.js --coin ETH --market USD -d 360


### PR DESCRIPTION
- Added new --market parameter for selected which market to view (e.g. you can now select any available trading pair)
- Default width/height changed to maximum terminal row/column count (Defaults to full-screen)

Very basic changes which seem to make sense to me. Could definitely be implemented in a more extensive manner.